### PR TITLE
Added D4000 calculation

### DIFF
--- a/bagpipes/catalogue/fit_catalogue.py
+++ b/bagpipes/catalogue/fit_catalogue.py
@@ -439,7 +439,7 @@ class fit_catalogue(object):
 
         if self.full_catalogue:
             self.vars += ["UV_colour", "VJ_colour"]
-            self.vars += ["beta_C94", "m_UV", "M_UV"]
+            self.vars += ["beta_C94", "m_UV", "M_UV", "D4000"]
             for frame in ["rest", "obs"]:
                 for property in ["xi_ion_caseB", "ndot_ion_caseB"]:
                     self.vars += [f"{property}_{frame}"]

--- a/bagpipes/fitting/check_priors.py
+++ b/bagpipes/fitting/check_priors.py
@@ -208,7 +208,7 @@ class check_priors:
         if "spectrum_full" in list(self.samples):
             return
 
-        all_names = ["photometry", "spectrum", "spectrum_full", "uvj", 'beta_C94', "m_UV", "M_UV", "indices", "burstiness"]
+        all_names = ["photometry", "spectrum", "spectrum_full", "uvj", 'beta_C94', "m_UV", "M_UV", "indices", "burstiness", "D4000"]
         for frame in ["rest", "obs"]:
             for property in ["xi_ion_caseB", "ndot_ion_caseB"]:
                 all_names.append(f"{property}_{frame}")

--- a/bagpipes/fitting/posterior.py
+++ b/bagpipes/fitting/posterior.py
@@ -210,7 +210,7 @@ class posterior(object):
                                          line_ratios_to_save = self.line_ratios_to_save)
         # Moved from above to enusre a model_galaxy is created
             
-        all_names = ["photometry", "spectrum", "spectrum_full", "uvj", 'beta_C94', "m_UV", "M_UV", "indices", "burstiness"]
+        all_names = ["photometry", "spectrum", "spectrum_full", "uvj", 'beta_C94', "m_UV", "M_UV", "indices", "burstiness", "D4000"]
         for frame in ["rest", "obs"]:
             for property in ["xi_ion_caseB", "ndot_ion_caseB"]:
                 all_names.append(f"{property}_{frame}")
@@ -301,7 +301,7 @@ class posterior(object):
                              lines_to_save = self.lines_to_save,
                              line_ratios_to_save = self.line_ratios_to_save)
 
-        all_names = ["photometry", "spectrum", "spectrum_full", "uvj", 'beta_C94', "m_UV", "M_UV", "indices", "burstiness"]
+        all_names = ["photometry", "spectrum", "spectrum_full", "uvj", 'beta_C94', "m_UV", "M_UV", "indices", "burstiness", 'D4000']
         for frame in ["rest", "obs"]:
             for property in ["xi_ion_caseB", "ndot_ion_caseB"]:
                 all_names.append(f"{property}_{frame}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added D4000 spectral index as an optional computed quantity. When enabled, it is included in model outputs, fitting advanced quantities, and posterior predictions.
  - Full catalogue mode now exports D4000 as a new column alongside existing metrics (e.g., beta_C94, m_UV, M_UV).

- Documentation
  - Updated in-code documentation to reflect D4000 availability in extra model outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->